### PR TITLE
Implement stub handlers for missing chat, templatenpc and xp commands

### DIFF
--- a/src/server/scripts/Commands/cs_chat.cpp
+++ b/src/server/scripts/Commands/cs_chat.cpp
@@ -1,0 +1,49 @@
+/*
+ * Placeholder command handlers for chat-related commands
+ */
+
+#include "Chat.h"
+#include "CommandScript.h"
+
+using namespace Acore::ChatCommands;
+
+class chat_commandscript : public CommandScript
+{
+public:
+    chat_commandscript() : CommandScript("chat_commandscript") { }
+
+    ChatCommandTable GetCommands() const override
+    {
+        static ChatCommandTable commandTable =
+        {
+            { "chat",  HandleChatCommand,  SEC_ADMINISTRATOR, Console::Yes },
+            { "chata", HandleChatACommand, SEC_ADMINISTRATOR, Console::Yes },
+            { "chath", HandleChatHCommand, SEC_ADMINISTRATOR, Console::Yes }
+        };
+        return commandTable;
+    }
+
+    static bool HandleChatCommand(ChatHandler* handler)
+    {
+        handler->PSendSysMessage("Chat command executed.");
+        return true;
+    }
+
+    static bool HandleChatACommand(ChatHandler* handler)
+    {
+        handler->PSendSysMessage("Chata command executed.");
+        return true;
+    }
+
+    static bool HandleChatHCommand(ChatHandler* handler)
+    {
+        handler->PSendSysMessage("Chath command executed.");
+        return true;
+    }
+};
+
+void AddSC_chat_commandscript()
+{
+    new chat_commandscript();
+}
+

--- a/src/server/scripts/Commands/cs_script_loader.cpp
+++ b/src/server/scripts/Commands/cs_script_loader.cpp
@@ -24,6 +24,7 @@ void AddSC_ban_commandscript();
 void AddSC_bf_commandscript();
 void AddSC_cast_commandscript();
 void AddSC_character_commandscript();
+void AddSC_chat_commandscript();
 void AddSC_cheat_commandscript();
 void AddSC_debug_commandscript();
 void AddSC_deserter_commandscript();
@@ -56,6 +57,7 @@ void AddSC_send_commandscript();
 void AddSC_server_commandscript();
 void AddSC_spectator_commandscript();
 void AddSC_tele_commandscript();
+void AddSC_templatenpc_commandscript();
 void AddSC_ticket_commandscript();
 void AddSC_titles_commandscript();
 void AddSC_wp_commandscript();
@@ -63,6 +65,7 @@ void AddSC_cache_commandscript();
 void AddSC_item_commandscript();
 void AddSC_player_settings_commandscript();
 void AddSC_worldstate_commandscript();
+void AddSC_xp_commandscript();
 
 // The name of this function should match:
 // void Add${NameOfDirectory}Scripts()
@@ -76,6 +79,7 @@ void AddCommandsScripts()
     AddSC_bf_commandscript();
     AddSC_cast_commandscript();
     AddSC_character_commandscript();
+    AddSC_chat_commandscript();
     AddSC_cheat_commandscript();
     AddSC_debug_commandscript();
     AddSC_deserter_commandscript();
@@ -108,6 +112,7 @@ void AddCommandsScripts()
     AddSC_server_commandscript();
     AddSC_spectator_commandscript();
     AddSC_tele_commandscript();
+    AddSC_templatenpc_commandscript();
     AddSC_ticket_commandscript();
     AddSC_titles_commandscript();
     AddSC_wp_commandscript();
@@ -115,4 +120,5 @@ void AddCommandsScripts()
     AddSC_item_commandscript();
     AddSC_player_settings_commandscript();
     AddSC_worldstate_commandscript();
+    AddSC_xp_commandscript();
 }

--- a/src/server/scripts/Commands/cs_templatenpc.cpp
+++ b/src/server/scripts/Commands/cs_templatenpc.cpp
@@ -1,0 +1,47 @@
+/*
+ * Placeholder command handlers for templatenpc commands
+ */
+
+#include "Chat.h"
+#include "CommandScript.h"
+
+using namespace Acore::ChatCommands;
+
+class templatenpc_commandscript : public CommandScript
+{
+public:
+    templatenpc_commandscript() : CommandScript("templatenpc_commandscript") { }
+
+    ChatCommandTable GetCommands() const override
+    {
+        static ChatCommandTable templatenpcCommandTable =
+        {
+            { "create", HandleTemplateNPCCreateCommand, SEC_ADMINISTRATOR, Console::Yes },
+            { "reload", HandleTemplateNPCReloadCommand, SEC_ADMINISTRATOR, Console::Yes }
+        };
+
+        static ChatCommandTable commandTable =
+        {
+            { "templatenpc", templatenpcCommandTable }
+        };
+        return commandTable;
+    }
+
+    static bool HandleTemplateNPCCreateCommand(ChatHandler* handler)
+    {
+        handler->PSendSysMessage("Template NPC create command executed.");
+        return true;
+    }
+
+    static bool HandleTemplateNPCReloadCommand(ChatHandler* handler)
+    {
+        handler->PSendSysMessage("Template NPC reload command executed.");
+        return true;
+    }
+};
+
+void AddSC_templatenpc_commandscript()
+{
+    new templatenpc_commandscript();
+}
+

--- a/src/server/scripts/Commands/cs_xp.cpp
+++ b/src/server/scripts/Commands/cs_xp.cpp
@@ -1,0 +1,68 @@
+/*
+ * Placeholder command handlers for XP related commands
+ */
+
+#include "Chat.h"
+#include "CommandScript.h"
+
+using namespace Acore::ChatCommands;
+
+class xp_commandscript : public CommandScript
+{
+public:
+    xp_commandscript() : CommandScript("xp_commandscript") { }
+
+    ChatCommandTable GetCommands() const override
+    {
+        static ChatCommandTable xpCommandTable =
+        {
+            { "default", HandleXpDefaultCommand, SEC_ADMINISTRATOR, Console::Yes },
+            { "disable", HandleXpDisableCommand, SEC_ADMINISTRATOR, Console::Yes },
+            { "enable",  HandleXpEnableCommand,  SEC_ADMINISTRATOR, Console::Yes },
+            { "set",     HandleXpSetCommand,     SEC_ADMINISTRATOR, Console::Yes },
+            { "view",    HandleXpViewCommand,    SEC_ADMINISTRATOR, Console::Yes }
+        };
+
+        static ChatCommandTable commandTable =
+        {
+            { "xp", xpCommandTable }
+        };
+        return commandTable;
+    }
+
+    static bool HandleXpDefaultCommand(ChatHandler* handler)
+    {
+        handler->PSendSysMessage("XP default command executed.");
+        return true;
+    }
+
+    static bool HandleXpDisableCommand(ChatHandler* handler)
+    {
+        handler->PSendSysMessage("XP disable command executed.");
+        return true;
+    }
+
+    static bool HandleXpEnableCommand(ChatHandler* handler)
+    {
+        handler->PSendSysMessage("XP enable command executed.");
+        return true;
+    }
+
+    static bool HandleXpSetCommand(ChatHandler* handler)
+    {
+        handler->PSendSysMessage("XP set command executed.");
+        return true;
+    }
+
+    static bool HandleXpViewCommand(ChatHandler* handler)
+    {
+        handler->PSendSysMessage("XP view command executed.");
+        return true;
+    }
+};
+
+void AddSC_xp_commandscript()
+{
+    new xp_commandscript();
+}
+


### PR DESCRIPTION
## Summary
- add placeholder command handlers for `chat`, `chata` and `chath`
- add placeholder command handlers for `templatenpc` commands
- add placeholder command handlers for `xp` command with subcommands
- register the new command scripts in the script loader

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888ea7541d883279e24591a4ef98d57