### PR TITLE
fix(DB): cleanup invalid event references

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1753813267927405443.sql
+++ b/data/sql/updates/pending_db_world/rev_1753813267927405443.sql
@@ -1,0 +1,8 @@
+-- DB update pending -> remove invalid event references
+-- Remove creatures in game_event_creature not present in creature table
+DELETE FROM `game_event_creature`
+WHERE `guid` NOT IN (SELECT `guid` FROM `creature`);
+
+-- Remove gameobjects in game_event_gameobject not present in gameobject table
+DELETE FROM `game_event_gameobject`
+WHERE `guid` NOT IN (SELECT `guid` FROM `gameobject`);


### PR DESCRIPTION
## Summary
- remove invalid `game_event_creature` rows that reference non-existing creature GUIDs
- remove invalid `game_event_gameobject` rows that reference non-existing gameobject GUIDs

## Testing
- `python apps/codestyle/codestyle-sql.py` *(fails: Could not fetch origin)*

------
https://chatgpt.com/codex/tasks/task_e_68890fe6582c8327b9316f33206f438b