### PR TITLE
Add server_progression table

### DIFF
--- a/data/sql/custom/db_world/server_progression.sql
+++ b/data/sql/custom/db_world/server_progression.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS `server_progression` (
+  `name` VARCHAR(64) NOT NULL,
+  `value` INT UNSIGNED NOT NULL DEFAULT 0,
+  PRIMARY KEY (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Server progression flags';
+
+REPLACE INTO `server_progression` (`name`, `value`) VALUES ('content_phase', 1);

--- a/doc/changelog/master.md
+++ b/doc/changelog/master.md
@@ -1,6 +1,9 @@
 ## 7.0.0-dev.1 | Commit: [0c4feb674444210da295751a0c4e5eefb9c771f1
 ](https://github.com/azerothcore/azerothcore-wotlk/commit/0c4feb674444210da295751a0c4e5eefb9c771f1
 
+### Added
+- Introduced `server_progression` table for tracking server content phase.
+
 
 ### How to upgrade
 

--- a/src/server/scripts/World/server_progression.cpp
+++ b/src/server/scripts/World/server_progression.cpp
@@ -1,0 +1,28 @@
+#include "WorldScript.h"
+#include "DatabaseEnv.h"
+#include "Log.h"
+
+class ServerProgressionInitializer : public WorldScript
+{
+public:
+    ServerProgressionInitializer() : WorldScript("ServerProgressionInitializer", { WORLDHOOK_ON_STARTUP }) { }
+
+    void OnStartup() override
+    {
+        WorldDatabase.DirectExecute(R"(
+            CREATE TABLE IF NOT EXISTS `server_progression` (
+                `name` VARCHAR(64) NOT NULL,
+                `value` INT UNSIGNED NOT NULL DEFAULT 0,
+                PRIMARY KEY (`name`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        )");
+
+        WorldDatabase.DirectExecute("REPLACE INTO `server_progression` (`name`, `value`) VALUES ('content_phase', 1)");
+        LOG_INFO("server.loading", "Server progression table initialized");
+    }
+};
+
+void AddSC_server_progression()
+{
+    new ServerProgressionInitializer();
+}

--- a/src/server/scripts/World/world_script_loader.cpp
+++ b/src/server/scripts/World/world_script_loader.cpp
@@ -32,6 +32,7 @@ void AddSC_action_ip_logger(); // location: scripts\World\action_ip_logger.cpp
 void AddSC_player_scripts();
 void AddSC_npc_stave_of_ancients();
 void AddSC_server_mail();
+void AddSC_server_progression();
 void AddSC_transport_zeppelins();
 void AddSC_suns_reach_reclamation();
 void AddSC_scourge_invasion();
@@ -56,6 +57,7 @@ void AddWorldScripts()
     AddSC_player_scripts();
     AddSC_npc_stave_of_ancients();
     AddSC_server_mail();
+    AddSC_server_progression();
     AddSC_transport_zeppelins();
     AddSC_suns_reach_reclamation();
     AddSC_scourge_invasion();


### PR DESCRIPTION
## Summary
- add `server_progression` table in custom world SQL
- init the table during world startup
- document new table in changelog

## Testing
- `apps/test-framework/run-tests.sh --all` *(fails: BATS is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688931eec9d8832788734a259bdd90a9