### PR TITLE
Clarify that repository contains no default modules

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -43,6 +43,8 @@ Here are the main points we focus on:
 
 AzerothCore is designed to be highly modular, allowing developers to extend and customize the game to suit their preferences or create unique gameplay experiences. This flexibility enables the addition of custom features, content, and modifications.
 
+No modules are bundled with this repository by default. The `modules/` directory remains empty until you add your own modules or those available in the community.
+
 We have a lot of modules already made by the community, many of which can be found in the [Module Catalogue](https://www.azerothcore.org/catalogue.html#/).
 
 ## Installation

--- a/modules/how_to_make_a_module.md
+++ b/modules/how_to_make_a_module.md
@@ -1,5 +1,8 @@
 # CREATE A NEW AZEROTHCORE MODULE
 
+The core repository does not include any modules. You can create your own or
+add ones provided by the community.
+
 1) Read this page first:
 
 http://www.azerothcore.org/wiki/Create-a-Module


### PR DESCRIPTION
## Summary
- document that no modules are shipped by default

## Testing
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_688931f0f4a88327a8778058f5f24ec2