### PR TITLE
chore(modules): use env bash in create_module.sh

### DIFF
--- a/modules/create_module.sh
+++ b/modules/create_module.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ## Just run it with bash or `git bash` on windows, and it will ask for the module's name and tada!
 ## By Barbz
 


### PR DESCRIPTION
## Summary
- make `create_module.sh` use `/usr/bin/env bash` to match other scripts

## Testing
- `bash -n modules/create_module.sh`


------
https://chatgpt.com/codex/tasks/task_e_688939fce1e08327b4db8232c182260b