### PR TITLE
Add server_progression table to custom SQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@
 /apps/joiner
 /deps/deno
 /data/sql/custom/*
+!/data/sql/custom/db_world/
+!/data/sql/custom/db_world/server_progression.sql
 /src/server/scripts/Custom/*
 !/src/server/scripts/Custom/README.md
 

--- a/data/sql/custom/README.md
+++ b/data/sql/custom/README.md
@@ -8,3 +8,4 @@ e.g:
 - UPDATES with fixed values
 
 etc.
+- server_progression.sql: creates `server_progression` table with default values (auto-imported during installation)

--- a/data/sql/custom/db_world/server_progression.sql
+++ b/data/sql/custom/db_world/server_progression.sql
@@ -1,0 +1,9 @@
+-- Custom server progression table
+CREATE TABLE IF NOT EXISTS `server_progression` (
+  `id` TINYINT UNSIGNED NOT NULL DEFAULT 1 COMMENT 'singleton row id',
+  `stage` TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Current server progression stage',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+REPLACE INTO `server_progression` (`id`, `stage`) VALUES (1, 0);
+


### PR DESCRIPTION
## Summary
- create `server_progression.sql` under `data/sql/custom/db_world`
- document the new custom SQL in `data/sql/custom/README.md`
- adjust `.gitignore` to allow tracking the new SQL file

## Testing
- `python3 ./apps/codestyle/codestyle-sql.py` *(fails: `'git fetch origin master' returned non-zero exit status 128`)*
- `bash apps/ci/ci-run-unit-tests.sh` *(fails: `var/build/obj/src/test/unit_tests: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68893a0567608327b5436267e9fa6d9a